### PR TITLE
Use exiting data to get Docker IP address

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var path = require('path');
-var exec = require('child_process').execSync;
 
 module.exports = function (context) {
 	var hooks = context.hooks,
@@ -10,11 +9,8 @@ module.exports = function (context) {
 	    docker = context.docker.docker,
 	    _context$environment = context.environment,
 	    userHome = _context$environment.userHome,
-	    dockerMachinePath = _context$environment.dockerMachinePath,
 	    dockerEnv = _context$environment.dockerEnv,
 	    fs = context.fileSystemJetpack;
-
-	var cache = {};
 
 	/**
   * Get the IP address of Flywheel's Docker instance.
@@ -22,16 +18,9 @@ module.exports = function (context) {
   * @param {String} machineName The Docker machine name. Default 'local-by-flywheel'.
   * @returns {String} The Docker machine IP.
   */
+
 	var getMachineIP = function getMachineIP() {
-		var dmp = dockerMachinePath.replace(/\s/gm, '\\ ');
-		var cmd = dmp + ' ip local-by-flywheel';
-
-		var IP = exec(cmd, function (err, stdout) {
-			console.log('stdout: ' + stdout);
-			console.error('err: ' + err);
-		});
-
-		return IP.toString().trim();
+		return dockerEnv.ip;
 	};
 
 	/**
@@ -53,6 +42,7 @@ module.exports = function (context) {
 
 		// Debugging.
 		console.log('site: %O', site);
+
 		publicCWD.file('site.json', { content: site });
 		publicCWD.file('context.json', { content: context.environment });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "local-addon-wp-cli-local",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "local-addon-wp-cli-local",
 	"productName": "WP-CLI Local integration",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "One-click configuration for SSH-less WP-CLI.",
 	"renderer": "lib/renderer.js",
 	"scripts": {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,16 +1,14 @@
 'use strict';
 
 const path = require('path');
-const exec = require('child_process').execSync;
 
 module.exports = function(context) {
 
 	const { hooks, notifier, React,
 		docker: { docker },
-		environment: {userHome, dockerMachinePath, dockerEnv},
+		environment: {userHome, dockerEnv},
 		fileSystemJetpack: fs,
 	} = context;
-	let cache = {};
 
 	/**
 	 * Get the IP address of Flywheel's Docker instance.
@@ -19,15 +17,7 @@ module.exports = function(context) {
 	 * @returns {String} The Docker machine IP.
 	 */
 	const getMachineIP = () => {
-		let dmp = dockerMachinePath.replace(/\s/gm,`\\ `);
-		let cmd = `${dmp} ip local-by-flywheel`;
-
-		let IP = exec(cmd, (err, stdout) => {
-			console.log(`stdout: ${stdout}`);
-			console.error(`err: ${err}`);
-		});
-
-		return IP.toString().trim();
+		return dockerEnv.ip;
 	};
 
 	/**
@@ -56,6 +46,7 @@ define( 'WP_DEBUG', false );`;
 
 		// Debugging.
 		console.log('site: %O', site);
+
 		publicCWD.file('site.json', {content: site});
 		publicCWD.file('context.json', {content: context.environment});
 


### PR DESCRIPTION
Since the IP address is already available, no need to run `exec` to query the Docker instance through the shell.